### PR TITLE
Suggest exif php extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Depending on the chosen Image implementation, you may need one of the following 
  - Imagick (with ImageMagick version 6.2.9 or later, except version 7.0.7-32)
  - Gmagick
 
+To read EXIF metadata (e.g. for autorotation), activate the PHP ``exif`` extension. This is optional: Imagine works
+without the PHP ``exif`` extension, but then it can't read and act on image orientation or other EXIF metadata.
+
 ### Installation using composer
 `php composer.phar require imagine/imagine`
 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4 || ^9.3"
     },
     "suggest": {
+        "ext-exif": "to read EXIF metadata",
         "ext-gd": "to use the GD implementation",
         "ext-imagick": "to use the Imagick implementation",
         "ext-gmagick": "to use the Gmagick implementation"


### PR DESCRIPTION
This should give users a hint why some functionality might not work
as intended. Some of the code soft-depends on the `exif` extension, it
won't hurt to suggest its installation.