### PR TITLE
Enables the GD support for resolution options group for PHP 7 >= 7.2, PHP 8.0.

### DIFF
--- a/docs/usage/introduction.rst
+++ b/docs/usage/introduction.rst
@@ -29,7 +29,7 @@ Install the dependencies using composer.phar and use Imagine :
 .. code-block:: none
 
     php composer.phar install
-    
+
 .. code-block:: php
 
     <?php
@@ -138,7 +138,7 @@ You can optionally specify the fill color for the new image, which defaults to o
    $size  = new Imagine\Image\Box(400, 300);
    $color = $palette->color('#000', 0);
    $image = $imagine->create($size, $color);
-   
+
 To use a solid background color, for example orange, provide an alpha of 100.
 
 .. code-block:: php
@@ -173,7 +173,7 @@ Three options groups are currently supported : quality, resolution and flatten.
    Default values are 75 for Jpeg quality, 7 for Png compression level, 75 for webp quality and 72 dpi for x/y-resolution.
 
 .. NOTE::
-   GD does not support resolution options group
+   GD does support resolution options group only with PHP 7 >= 7.2, PHP 8
 
 The following example demonstrates the basic quality settings.
 

--- a/src/Gd/Image.php
+++ b/src/Gd/Image.php
@@ -188,7 +188,7 @@ final class Image extends AbstractImage implements InfoProvider
                 throw new RuntimeException('Image paste operation failed');
             }
         } elseif ($alpha > 0) {
-            if (imagecopymerge(/*dst_im*/$this->resource, /*src_im*/$image->resource, /*dst_x*/$start->getX(), /*dst_y*/$start->getY(), /*src_x*/0, /*src_y*/0, /*src_w*/$size->getWidth(), /*src_h*/$size->getHeight(), /*pct*/$alpha) === false) {
+            if (imagecopymerge(/*dst_im*/$this->resource, /*src_im*/ $image->resource, /*dst_x*/ $start->getX(), /*dst_y*/ $start->getY(), /*src_x*/ 0, /*src_y*/ 0, /*src_w*/ $size->getWidth(), /*src_h*/ $size->getHeight(), /*pct*/ $alpha) === false) {
                 throw new RuntimeException('Image paste operation failed');
             }
         }
@@ -728,7 +728,6 @@ final class Image extends AbstractImage implements InfoProvider
         }
 
         if (isset($options['resolution-units']) && isset($options['resolution-x']) && function_exists('imageresolution')) {
-
             $resolution_x = $options['resolution-x'];
             $resolution_y = isset($options['resolution-y']) ? $options['resolution-y'] : $resolution_x;
 

--- a/src/Gd/Image.php
+++ b/src/Gd/Image.php
@@ -727,6 +727,19 @@ final class Image extends AbstractImage implements InfoProvider
                 break;
         }
 
+        if (isset($options['resolution-units']) && isset($options['resolution-x']) && function_exists('imageresolution')) {
+
+            $resolution_x = $options['resolution-x'];
+            $resolution_y = isset($options['resolution-y']) ? $options['resolution-y'] : $resolution_x;
+
+            if ($options['resolution-units'] === ImageInterface::RESOLUTION_PIXELSPERCENTIMETER) {
+                $resolution_x = $resolution_x * ImageInterface::RESOLUTION_PPC_TO_PPI_MULTIPLIER;
+                $resolution_y = $resolution_y * ImageInterface::RESOLUTION_PPC_TO_PPI_MULTIPLIER;
+            }
+
+            imageresolution($this->resource, $resolution_x, $resolution_y);
+        }
+
         ErrorHandling::throwingRuntimeException(E_WARNING | E_NOTICE, function () use ($saveFunction, $args) {
             if (call_user_func_array($saveFunction, $args) === false) {
                 throw new RuntimeException('Save operation failed');

--- a/src/Gd/Image.php
+++ b/src/Gd/Image.php
@@ -728,15 +728,15 @@ final class Image extends AbstractImage implements InfoProvider
         }
 
         if (isset($options['resolution-units']) && isset($options['resolution-x']) && function_exists('imageresolution')) {
-            $resolution_x = $options['resolution-x'];
-            $resolution_y = isset($options['resolution-y']) ? $options['resolution-y'] : $resolution_x;
+            $resolutionX = $options['resolution-x'];
+            $resolutionY = isset($options['resolution-y']) ? $options['resolution-y'] : $resolutionX;
 
             if ($options['resolution-units'] === ImageInterface::RESOLUTION_PIXELSPERCENTIMETER) {
-                $resolution_x = $resolution_x * ImageInterface::RESOLUTION_PPC_TO_PPI_MULTIPLIER;
-                $resolution_y = $resolution_y * ImageInterface::RESOLUTION_PPC_TO_PPI_MULTIPLIER;
+                $resolutionX *= ImageInterface::RESOLUTION_PPC_TO_PPI_MULTIPLIER;
+                $resolutionY *= ImageInterface::RESOLUTION_PPC_TO_PPI_MULTIPLIER;
             }
 
-            imageresolution($this->resource, $resolution_x, $resolution_y);
+            imageresolution($this->resource, $resolutionX, $resolutionY);
         }
 
         ErrorHandling::throwingRuntimeException(E_WARNING | E_NOTICE, function () use ($saveFunction, $args) {

--- a/src/Image/ImageInterface.php
+++ b/src/Image/ImageInterface.php
@@ -33,7 +33,7 @@ interface ImageInterface extends ManipulatorInterface
     const RESOLUTION_PIXELSPERCENTIMETER = 'ppc';
 
     /**
-     * Multiplier for converting resolution from ppc to ppi
+     * Multiplier for converting resolution from ppc to ppi.
      *
      * @var float
      */

--- a/src/Image/ImageInterface.php
+++ b/src/Image/ImageInterface.php
@@ -33,6 +33,13 @@ interface ImageInterface extends ManipulatorInterface
     const RESOLUTION_PIXELSPERCENTIMETER = 'ppc';
 
     /**
+     * Multiplier for converting resolution from ppc to ppi
+     *
+     * @var float
+     */
+    const RESOLUTION_PPC_TO_PPI_MULTIPLIER = 2.54;
+
+    /**
      * Image interlacing: none.
      *
      * @var string


### PR DESCRIPTION
Example:

```
<?php

use Imagine\Image\ImageInterface;

$imagine = new Imagine\Gd\Imagine();

$options = array(
    'resolution-units' => ImageInterface::RESOLUTION_PIXELSPERINCH,
    'resolution-x' => 300,
    'resolution-y' => 300,
);

$imagine->open('/path/to/image.jpg')->save('/path/to/image.jpg', $options);
```