### PR TITLE
Fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "0.7-dev"
+            "dev-develop": "1.x-dev"
         }
     },
     "archive": {


### PR DESCRIPTION
The current branch alias implies that the develop branch is in the 0.7 version family.  The develop branch is presently the 1.x branch.
