### PR TITLE
Fix undefined variable $engineRawVersion

### DIFF
--- a/src/Gmagick/DriverInfo.php
+++ b/src/Gmagick/DriverInfo.php
@@ -39,7 +39,7 @@ class DriverInfo extends AbstractInfo
             if (preg_match('/^.*?(\d+\.\d+\.\d+(-\d+)?(\s+Q\d+)?)/i', $engineVersion['versionString'], $m)) {
                 $engineRawVersion = $m[1];
             } else {
-                $engineRawVersion = $engineRawVersion['versionString'];
+                $engineRawVersion = $engineVersion['versionString'];
             }
         } else {
             $engineRawVersion = '';

--- a/src/Imagick/DriverInfo.php
+++ b/src/Imagick/DriverInfo.php
@@ -47,7 +47,7 @@ class DriverInfo extends AbstractInfo
             if (preg_match('/^.*?(\d+\.\d+\.\d+(-\d+)?(\s+Q\d+)?)/i', $engineVersion['versionString'], $m)) {
                 $engineRawVersion = $m[1];
             } else {
-                $engineRawVersion = $engineRawVersion['versionString'];
+                $engineRawVersion = $engineVersion['versionString'];
             }
         } else {
             $engineRawVersion = '';


### PR DESCRIPTION
With the 1.3.0 release, an error now occured when using the Imagick or GMagick driver.

`Undefined variable $engineRawVersion`