### PR TITLE
Fix invalid format MIME type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ### NEXT (YYYY-MM-DD)
-
+*  Fix invalid format MIME type definition (#835, @xdanik)
 
 ### 1.3.2 (2022-04-01)
 * Workaround for a bug in PHP 7.3+opcache that causes segmentation faults (#826, #829, #828, @ausi, @mnocon, @mlocati)

--- a/src/Image/Format.php
+++ b/src/Image/Format.php
@@ -154,7 +154,7 @@ class Format
             case static::ID_JPEG:
                 return new static($formatID, 'image/jpeg', 'jpg', array('jpg', 'pjpeg', 'jfif'));
             case static::ID_WBMP:
-                return new static($formatID, 'vnd.wap.wbmp', 'jpg');
+                return new static($formatID, 'image/vnd.wap.wbmp', $formatID);
             default:
                 return new static($formatID, "image/{$formatID}", $formatID);
         }

--- a/src/Image/Format.php
+++ b/src/Image/Format.php
@@ -152,11 +152,11 @@ class Format
     {
         switch ($formatID) {
             case static::ID_JPEG:
-                return new static($formatID, 'jpg', 'image/jpeg', array('jpg', 'pjpeg', 'jfif'));
+                return new static($formatID, 'image/jpeg', 'jpg', array('jpg', 'pjpeg', 'jfif'));
             case static::ID_WBMP:
-                return new static($formatID, 'jpg', 'vnd.wap.wbmp');
+                return new static($formatID, 'vnd.wap.wbmp', 'jpg');
             default:
-                return new static($formatID, $formatID, "image/{$formatID}");
+                return new static($formatID, "image/{$formatID}", $formatID);
         }
     }
 }

--- a/tests/tests/Filter/Advanced/BlackWhiteTest.php
+++ b/tests/tests/Filter/Advanced/BlackWhiteTest.php
@@ -20,6 +20,7 @@ class BlackWhiteTest extends FilterTestCase
 {
     /**
      * @dataProvider getData
+     *
      * @doesNotPerformAssertions
      *
      * @param int $border

--- a/tests/tests/Image/AbstractImageTest.php
+++ b/tests/tests/Image/AbstractImageTest.php
@@ -1182,6 +1182,7 @@ abstract class AbstractImageTest extends ImagineTestCase implements InfoProvider
 
     /**
      * @dataProvider provideExensions
+     *
      * @doesNotPerformAssertions
      *
      * @param string $extension

--- a/tests/tests/Image/FormatTest.php
+++ b/tests/tests/Image/FormatTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Imagine package.
+ *
+ * (c) Bulat Shakirzyanov <mallluhuct@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Imagine\Test\Image;
+
+use Imagine\Image\Format;
+use Imagine\Test\ImagineTestCase;
+
+class FormatTest extends ImagineTestCase
+{
+    public function formatIdMimeTypeProvider()
+    {
+        return array(
+            array(Format::ID_JPEG, 'image/jpeg'),
+            array(Format::ID_WBMP, 'image/vnd.wap.wbmp'),
+            array(Format::ID_AVIF, 'image/avif'),
+            array(Format::ID_WEBP, 'image/webp'),
+        );
+    }
+
+    /**
+     * @dataProvider formatIdMimeTypeProvider
+     *
+     * @param string $formatId
+     * @param string $expectedMimeType
+     */
+    public function testMimeTypes($formatId, $expectedMimeType)
+    {
+        $format = Format::get($formatId);
+
+        $this->assertEquals($format->getMimeType(), $expectedMimeType);
+    }
+}

--- a/tests/tests/Issues/Issue131Test.php
+++ b/tests/tests/Issues/Issue131Test.php
@@ -67,6 +67,7 @@ class Issue131Test extends ImagineTestCase
 
     /**
      * @doesNotPerformAssertions
+     *
      * @group imagick
      */
     public function testShouldSaveOneFileWithImagick()


### PR DESCRIPTION
I have discovered that $image->show() was setting invalid Content-Type header. "jpg" in case of "jpg" format instead of "image/jpg".

There seems to be an invalid argument order in the constructor call to Imagine\Image\Format.
The constructor signature is:
`private function __construct($id, $mimeType, $canonicalFileExtension, $alternativeIDs = array())`

While callers were clearly setting MIME type into 3. argument instead of second one. 
