### PR TITLE
PHP 8 compatibility.

### DIFF
--- a/src/Image/Point.php
+++ b/src/Image/Point.php
@@ -38,6 +38,12 @@ final class Point implements PointInterface
      */
     public function __construct($x, $y)
     {
+        if (!\is_int($x)) {
+            $x = (int) round($x);
+        }
+        if (!\is_int($y)) {
+            $y = (int) round($y);
+        }
         if ($x < 0 || $y < 0) {
             throw new InvalidArgumentException(sprintf('A coordinate cannot be positioned outside of a bounding box (x: %s, y: %s given)', $x, $y));
         }

--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -161,7 +161,7 @@ final class Image extends AbstractImage implements InfoProvider
                 }
                 $this->imagick = $this->imagick->deconstructImages();
             } else {
-                $this->imagick->cropImage((int)$size->getWidth(), (int)$size->getHeight(), (int)$start->getX(), (int)$start->getY());
+                $this->imagick->cropImage($size->getWidth(), $size->getHeight(), $start->getX(), $start->getY());
                 // Reset canvas for gif format
                 $this->imagick->setImagePage(0, 0, 0, 0);
             }

--- a/src/Imagick/Image.php
+++ b/src/Imagick/Image.php
@@ -161,7 +161,7 @@ final class Image extends AbstractImage implements InfoProvider
                 }
                 $this->imagick = $this->imagick->deconstructImages();
             } else {
-                $this->imagick->cropImage($size->getWidth(), $size->getHeight(), $start->getX(), $start->getY());
+                $this->imagick->cropImage((int)$size->getWidth(), (int)$size->getHeight(), (int)$start->getX(), (int)$start->getY());
                 // Reset canvas for gif format
                 $this->imagick->setImagePage(0, 0, 0, 0);
             }


### PR DESCRIPTION
Fix for
The error is thrown in the HumHub project:

PHP Deprecated Warning 'yii\\base\\ErrorException' with message 'Implicit conversion from float-string "42.95454545454545" to int loses precision' 

in /www/wwwroot/yta.yaro.info/protected/vendor/imagine/imagine/src/Imagick/Image.php:164

Stack trace:
#0 [internal function]: yii\\base\\ErrorHandler->handleError() #1 /www/wwwroot/yta.yaro.info/protected/vendor/imagine/imagine/src/Imagick/Image.php(164): Imagick->cropImage() #2 /www/wwwroot/yta.yaro.info/protected/humhub/libs/ProfileImage.p...",

<!--
PLEASE INCLUDE A TEST FOR THIS PULL REQUEST.
PULL REQUESTS NOT COVERED BY TEST CASES WILL TAKE MUCH MORE TIME TO BE REVIEWED.

In case of bug fixes, the correct approach to submit a pull request is:
1. write a test case that shows the problem (tests should fail)
2. submit the pull request
3. update the pull request with a fix for the bug
-->
