### PR TITLE
remove warning, Deprecated: Implicit conversion from float to int loses precision in PHP 8.2

### DIFF
--- a/src/Image/Point.php
+++ b/src/Image/Point.php
@@ -42,8 +42,8 @@ final class Point implements PointInterface
             throw new InvalidArgumentException(sprintf('A coordinate cannot be positioned outside of a bounding box (x: %s, y: %s given)', $x, $y));
         }
 
-        $this->x = $x;
-        $this->y = $y;
+        $this->x = ceil($x);
+        $this->y = ceil($y);
     }
 
     /**

--- a/src/Image/Point.php
+++ b/src/Image/Point.php
@@ -38,12 +38,19 @@ final class Point implements PointInterface
      */
     public function __construct($x, $y)
     {
+        if (!is_numeric($x) || !is_numeric($y)) {
+            throw new InvalidArgumentException('x or y must be numeric');
+        }
+
+        $x = (int) round((float) $x);
+        $y = (int) round((float) $y);
+
         if ($x < 0 || $y < 0) {
             throw new InvalidArgumentException(sprintf('A coordinate cannot be positioned outside of a bounding box (x: %s, y: %s given)', $x, $y));
         }
 
-        $this->x = ceil($x);
-        $this->y = ceil($y);
+        $this->x = $x;
+        $this->y = $y;
     }
 
     /**


### PR DESCRIPTION
remove deprecated message from php8.2

edit: i guest this PR related to #843 😳

`Deprecated: Implicit conversion from float 345.5 to int loses precision in ...\vendor\imagine\imagine\src\Gd\Image.php on line 191`

on https://github.com/php-imagine/Imagine/blob/6d5b83a403d17236ba3b7e52e3c2caf4e937d0f0/src/Gd/Image.php#L191
`imagecopymerge()` need `dst_x` and `dst_y` to be int.

but `$start->getX()` and `$start->getY()` could return float.

<!--
PLEASE INCLUDE A TEST FOR THIS PULL REQUEST.
PULL REQUESTS NOT COVERED BY TEST CASES WILL TAKE MUCH MORE TIME TO BE REVIEWED.

In case of bug fixes, the correct approach to submit a pull request is:
1. write a test case that shows the problem (tests should fail)
2. submit the pull request
3. update the pull request with a fix for the bug
-->
