### PR TITLE
Add support for webp_lossless to GD and GMagick

### DIFF
--- a/src/Gd/Image.php
+++ b/src/Gd/Image.php
@@ -730,7 +730,9 @@ final class Image extends AbstractImage implements InfoProvider
                         $options['webp_quality'] = $options['quality'];
                     }
                 }
-                if (isset($options['webp_quality'])) {
+                if (!empty($options['webp_lossless'])) {
+                    $result[] = defined('IMG_WEBP_LOSSLESS') ? IMG_WEBP_LOSSLESS : 100;
+                } elseif (isset($options['webp_quality'])) {
                     if ($options['webp_quality'] < 0 || $options['webp_quality'] > 100) {
                         throw new InvalidArgumentException('webp_quality option should be an integer from 0 to 100');
                     }

--- a/src/Gmagick/Image.php
+++ b/src/Gmagick/Image.php
@@ -368,6 +368,13 @@ final class Image extends AbstractImage implements InfoProvider
                 if (isset($options['webp_quality'])) {
                     $image->setCompressionQuality($options['webp_quality']);
                 }
+                if (isset($options['webp_lossless'])) {
+                    if (method_exists($image, 'setimageoption')) {
+                        $image->setimageoption('webp', 'lossless', $options['webp_lossless'] ? 'true' : 'false');
+                    } elseif ($options['webp_lossless']) {
+                        $image->setCompressionQuality(100);
+                    }
+                }
                 break;
         }
         if (isset($options['resolution-units']) && isset($options['resolution-x']) && isset($options['resolution-y'])) {

--- a/tests/tests/Image/AbstractImageTest.php
+++ b/tests/tests/Image/AbstractImageTest.php
@@ -1127,6 +1127,7 @@ abstract class AbstractImageTest extends ImagineTestCase implements InfoProvider
             array(Format::ID_JPEG, array('jpeg_quality' => 0), array('jpeg_quality' => 100)),
             array(Format::ID_PNG, array('png_compression_level' => 9), array('png_compression_level' => 0)),
             array(Format::ID_WEBP, array('webp_quality' => 0), array('webp_quality' => 100)),
+            array(Format::ID_WEBP, array('webp_quality' => 0), array('webp_lossless' => true)),
             array(Format::ID_AVIF, array('avif_quality' => 0), array('avif_quality' => 100)),
             array(Format::ID_AVIF, array('avif_quality' => 0), array('avif_lossless' => true)),
             array(Format::ID_HEIC, array('heic_quality' => 0), array('heic_quality' => 100)),


### PR DESCRIPTION
Fixes #857 

The IMagick driver already supports the `webp_lossless` option, see https://github.com/php-imagine/Imagine/blob/922e0327a6b36d1da0acca69993ac85395adcea6/src/Imagick/Image.php#L829-L831

This pull request adds support for GD and GMagick too.